### PR TITLE
Update protobufjs version

### DIFF
--- a/packages/grpc-protobufjs/package.json
+++ b/packages/grpc-protobufjs/package.json
@@ -35,7 +35,7 @@
     "clang-format": "^1.2.2",
     "gts": "^0.5.3",
     "lodash": "^4.17.5",
-    "protobufjs": "^6.8.5",
+    "protobufjs": "^6.8.6",
     "typescript": "~2.7.2"
   }
 }


### PR DESCRIPTION
Fixes [ReDoS Vulnerability](https://github.com/dcodeIO/protobuf.js/releases/tag/6.8.6)